### PR TITLE
[WLDR-102] Init process fixes

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -4,7 +4,6 @@ MW_RECAPTCHA_SITE_KEY=
 MW_RECAPTCHA_SECRET_KEY=
 
 MW_DB_NAME=
-MW_DB_INSTALLDB_USER=
 MW_DB_INSTALLDB_PASS=
 
 # This user will be created if the database will be initialized from scratch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,9 @@ services:
             - MW_ADMIN_USER
             - MW_ADMIN_PASS
             - MW_DB_NAME
-            - MW_DB_INSTALLDB_USER
+            - MW_DB_INSTALLDB_USER=root
             - MW_DB_INSTALLDB_PASS
-            - MW_DB_USER=$MW_DB_INSTALLDB_USER
+            - MW_DB_USER=root
             - MW_DB_PASS=$MW_DB_INSTALLDB_PASS
             - MW_SECRET_KEY
 
@@ -51,7 +51,6 @@ services:
         volumes:
             - ./_data/mediawiki:/mediawiki
             - ./_logs/httpd:/var/log/httpd
-            - ./web/DockerSettings.php:/var/www/html/w/LocalSettings.php
             - ./_resources/CustomSettings.php:/var/www/html/w/CustomSettings.php
             - ./_resources/.htaccess:/var/www/html/.htaccess
             - ./_resources/favicon.ico:/var/www/html/w/favicon.ico


### PR DESCRIPTION
Removes MW_DB_INSTALLDB_USER user from .env_example because the database user is always root due to docker-compose.yml, updates the `MW_DB_INSTALLDB_USER` and `MW_DB_USER` in the composition file to always use `root` user

Removes linking of `./web/DockerSettings.php` into the container as `/var/www/html/w/LocalSettings.php` and instead back-ports https://github.com/WikiTeq/docker-wikiteq-mediawiki/commit/8829647fe0a6853e1089f73a1bb09b33892609f5